### PR TITLE
Pirate macro

### DIFF
--- a/src/NamedPlus.jl
+++ b/src/NamedPlus.jl
@@ -19,7 +19,7 @@ include("permute.jl")
 export canonise, align, align_sum!, align_prod!
 
 include("create.jl")
-export named, diagonal, outer, ..
+export named, diagonal, outer, .., @pirate
 
 include("reshape.jl")
 

--- a/src/NamedPlus.jl
+++ b/src/NamedPlus.jl
@@ -10,7 +10,7 @@ include("recursion.jl")
 export getnames, nameless
 
 include("int.jl")
-export NamedInt
+export NamedInt, ᵅ
 
 include("macro.jl")
 export @named

--- a/src/create.jl
+++ b/src/create.jl
@@ -60,81 +60,29 @@ function named(A::AbstractArray, names::Union{Symbol, Dots}...)
     end
 end
 
-#################### ZERO, ONES ####################
+#################### PIRACY ####################
 
-zero_doc = """
-    zeros(; r=2)
-    ones(Int8; r=2, c=3)
-    fill(3.14; c=3)
-
-These are piratically overloaded to make `NamedDimsArray`s.
-The zero-dimensional methods like `fill(3)` should stil work fine.
-See also `rand(Float64; i=10)` and `range(; i=10)`.
-```
-julia> fill(π, α=1, β=1)
-1×1 NamedDimsArray(::Array{Irrational{:π},2}, (:α, :β)):
-      → :β
-↓ :α  π
-
-julia> zeros(ComplexF64, r=2, c=3)
-2×3 NamedDimsArray(::Array{Complex{Float64},2}, (:r, :c)):
-      → :c
-↓ :r  0.0+0.0im  0.0+0.0im  0.0+0.0im
-      0.0+0.0im  0.0+0.0im  0.0+0.0im
-
-julia> using OffsetArrays
-
-julia> zeros(_=1, col=11:17)
-1×7 NamedDimsArray(OffsetArray(::Array{Float64,2}, 1:1, 11:17), (:_, :col)):
-      → :col
-↓ :_  0.0  0.0  0.0  0.0  0.0  0.0  0.0
-```
 """
-@doc zero_doc
-Base.zeros(; kw...) = zeros(Float64; kw...)
+    @pirate Base
 
-function Base.zeros(T::Type; kw...)
-    if length(kw) >= 1
-        NamedDimsArray(zeros(T, kw.data...), kw.itr)
-    else
-        fill(zero(T), ())
+This will define all sorts of convenient methods,
+like `ones(i=2)` and `rand(Float64, j=3)`.
+"""
+macro pirate(ex=:Base)
+    ex == :Base || error()
+    str = read(joinpath(@__DIR__, "pirate.jl"), String)
+    # @show length(str)
+    n = 1
+    out = quote end
+    while true
+        expr, n = Meta.parse(str, n; greedy=true)
+        expr === nothing && break
+        push!(out.args, expr)
+        # @show n expr
     end
+    push!(out.args, nothing)
+    out
 end
-
-@doc zero_doc
-Base.ones(; kw...) = ones(Float64; kw...)
-
-function Base.ones(T::Type; kw...)
-    if length(kw) >= 1
-        NamedDimsArray(ones(T, kw.data...), kw.itr)
-    else
-        fill(one(T), ())
-    end
-end
-
-@doc zero_doc
-function Base.fill(v; kw...)
-    if length(kw) >= 1
-        NamedDimsArray(fill(v, Tuple(kw.data)), kw.itr)
-    else
-        fill(v, ())
-    end
-end
-
-#=# Note that rand(; kw...) is worse piracy than ones(; kw...)
-
-julia> @which zeros()
-zeros(dims::Union{Integer, AbstractUnitRange}...) in Base at array.jl:454
-
-julia> @which fill(1)
-fill(v, dims::Union{Integer, AbstractUnitRange}...) in Base at array.jl:407
-
-julia> @which rand()
-rand() in Random at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.3/Random/src/Random.jl:256
-
-julia> @which rand(Random.default_rng())
-rand(rng::AbstractRNG) in Random at
-=#
 
 # Random.default_rng()::AbstractRNG
 using Random
@@ -142,55 +90,6 @@ if VERSION < v"1.3-"
     RNG() = Random.GLOBAL_RNG
 else
     const RNG = Random.default_rng
-end
-# @doc zero_doc
-# Base.rand(; kw...) = rand(Float64; kw...)
-# @doc zero_doc
-# Base.randn(; kw...) = rand(Float64; kw...)
-
-"""
-    rand(Float32; c=3, d=4)
-    randn(Float64; c=3, d=4)
-
-Keyword overload for `rand` needs a type, otherwise too piratical.
-See also `zeros(; c=3, d=4)`, which works with or without the type.
-```
-julia> rand(Int8, a=2, b=4)
-2×4 NamedDimsArray(::Array{Int8,2}, (:a, :b)):
-      → :b
-↓ :a   32   21   87  105
-      -42  -32  -35   33
-```
-"""
-function Base.rand(T::Type{Tn}; kw...) where {Tn<:Number}
-    if length(kw) >= 1
-        NamedDimsArray(rand(T, kw.data...), kw.itr)
-    else
-        rand(RNG(), T) # @btime rand() unchanged
-    end
-end
-function Base.randn(T::Type{Tn}; kw...) where {Tn<:Number}
-    if length(kw) >= 1
-        NamedDimsArray(randn(T, kw.data...), kw.itr)
-    else
-        randn(RNG(), T)
-    end
-end
-
-"""
-    range(; i=10) == NamedDimsArray(1:10, :i)
-
-Keyword piracy to make ranges.
-"""
-function Base.range(; kw...)
-    if length(kw.itr) == 1
-        NamedDimsArray(_ensure_range(kw.data[1]), kw.itr)
-    elseif length(kw.itr) >= 2
-        data = outer(_ensure_range.(Tuple(kw.data))...)
-        NamedDimsArray(data, kw.itr)
-    else
-        error("range() with no arguments still doesn't mean anything")
-    end
 end
 
 _ensure_range(n::Integer) = Base.OneTo(n)

--- a/src/create.jl
+++ b/src/create.jl
@@ -68,21 +68,38 @@ end
 This will define all sorts of convenient methods,
 like `ones(i=2)` and `rand(Float64, j=3)`.
 """
-macro pirate(ex=:Base)
-    ex == :Base || error()
-    str = read(joinpath(@__DIR__, "pirate.jl"), String)
-    # @show length(str)
-    n = 1
+macro pirate(exs...=(:Base,))
     out = quote end
-    while true
-        expr, n = Meta.parse(str, n; greedy=true)
-        expr === nothing && break
-        push!(out.args, expr)
-        # @show n expr
+
+    if :Base in exs
+        str = read(joinpath(@__DIR__, "pirate.jl"), String)
+        n = 1
+        while true
+            expr, n = Meta.parse(str, n; greedy=true)
+            expr === nothing && break
+            push!(out.args, expr)
+        end
+        push!(out.args, nothing)
     end
-    push!(out.args, nothing)
+
+#     @pirate NamedDims
+# This causes `size(nda)` to return a tuple of `NamedInt`s,
+# for propagating names through some code.
+    # if :NamedDims in exs
+    #     str = read(joinpath(@__DIR__, "int.jl"), String)
+    #     n = 1
+    #     while true
+    #         expr, n = Meta.parse(str, n; greedy=true)
+    #         expr === nothing && break
+    #         push!(out.args, expr)
+    #     end
+    #     push!(out.args, nothing)
+    # end
+
     out
 end
+
+# export NamedInt, ᵅ
 
 # Random.default_rng()::AbstractRNG
 using Random

--- a/src/int.jl
+++ b/src/int.jl
@@ -16,8 +16,6 @@ M2 * x
 
 #################### NAMED-INT TYPE ####################
 
-export ᵅ
-
 """
     NamedInt(μ=3)
 
@@ -44,6 +42,7 @@ Base.show(io::IO, ::MIME"text/plain", x::NamedInt{L}) where {L} =
 
 # These operation preserve names, firstly to make printout re-pastable, but also...
 const ᵅ = NamedInt(1, :_)
+
 # Base.:*(x::Integer, y::NamedInt{L}) where {L} = NamedInt(x * y.val, _join(:_, L))
 Base.:*(x::NamedInt{Lx}, y::NamedInt{Ly}) where {Lx, Ly} = NamedInt(x.val * y.val, _join(Lx, Ly))
 # Base.literal_pow(::typeof(^), x::NamedInt{L}, ::Val{2}) where {L} =

--- a/src/pirate.jl
+++ b/src/pirate.jl
@@ -1,0 +1,136 @@
+#################### ZERO, ONES ####################
+
+_zero_doc = """
+    zeros(; r=2)
+    ones(Int8; r=2, c=3)
+    fill(3.14; c=3)
+
+These are piratically overloaded to make `NamedDimsArray`s.
+The zero-dimensional methods like `fill(3)` should stil work fine.
+See also `rand(Float64; i=10)` and `range(; i=10)`.
+```
+julia> fill(π, α=1, β=1)
+1×1 NamedDimsArray(::Array{Irrational{:π},2}, (:α, :β)):
+      → :β
+↓ :α  π
+
+julia> zeros(ComplexF64, r=2, c=3)
+2×3 NamedDimsArray(::Array{Complex{Float64},2}, (:r, :c)):
+      → :c
+↓ :r  0.0+0.0im  0.0+0.0im  0.0+0.0im
+      0.0+0.0im  0.0+0.0im  0.0+0.0im
+
+julia> using OffsetArrays
+
+julia> zeros(_=1, col=11:17)
+1×7 NamedDimsArray(OffsetArray(::Array{Float64,2}, 1:1, 11:17), (:_, :col)):
+      → :col
+↓ :_  0.0  0.0  0.0  0.0  0.0  0.0  0.0
+```
+"""
+@doc _zero_doc
+Base.zeros(; kw...) = zeros(Float64; kw...)
+
+function Base.zeros(T::Type; kw...)
+    if length(kw) >= 1
+        NamedDimsArray(zeros(T, kw.data...), kw.itr)
+    else
+        fill(zero(T), ())
+    end
+end
+
+@doc _zero_doc
+Base.ones(; kw...) = ones(Float64; kw...)
+
+function Base.ones(T::Type; kw...)
+    if length(kw) >= 1
+        NamedDimsArray(ones(T, kw.data...), kw.itr)
+    else
+        fill(one(T), ())
+    end
+end
+
+@doc _zero_doc
+function Base.fill(v; kw...)
+    if length(kw) >= 1
+        NamedDimsArray(fill(v, Tuple(kw.data)), kw.itr)
+    else
+        fill(v, ())
+    end
+end
+
+#=# Note that rand(; kw...) is worse piracy than ones(; kw...)
+
+julia> @which zeros()
+zeros(dims::Union{Integer, AbstractUnitRange}...) in Base at array.jl:454
+
+julia> @which fill(1)
+fill(v, dims::Union{Integer, AbstractUnitRange}...) in Base at array.jl:407
+
+julia> @which rand()
+rand() in Random at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.3/Random/src/Random.jl:256
+
+julia> @which rand(Random.default_rng())
+rand(rng::AbstractRNG) in Random at
+=#
+
+# @doc _zero_doc
+# Base.rand(; kw...) = rand(Float64; kw...)
+# @doc _zero_doc
+# Base.randn(; kw...) = rand(Float64; kw...)
+
+"""
+    rand(Float32; c=3, d=4)
+    randn(Float64; c=3, d=4)
+
+Keyword overload for `rand` needs a type, otherwise too piratical.
+See also `zeros(; c=3, d=4)`, which works with or without the type.
+```
+julia> rand(Int8, a=2, b=4)
+2×4 NamedDimsArray(::Array{Int8,2}, (:a, :b)):
+      → :b
+↓ :a   32   21   87  105
+      -42  -32  -35   33
+```
+"""
+function Base.rand(T::Type{Tn}; kw...) where {Tn<:Number}
+    if length(kw) >= 1
+        NamedDimsArray(rand(T, kw.data...), kw.itr)
+    else
+        rand(NamedPlus.RNG(), T) # @btime rand() unchanged
+    end
+end
+function Base.randn(T::Type{Tn}; kw...) where {Tn<:Number}
+    if length(kw) >= 1
+        NamedDimsArray(randn(T, kw.data...), kw.itr)
+    else
+        randn(NamedPlus.RNG(), T)
+    end
+end
+
+"""
+    range(; i=10) == NamedDimsArray(1:10, :i)
+
+Keyword piracy to make ranges.
+"""
+function Base.range(; kw...)
+    if length(kw.itr) == 1
+        NamedDimsArray(NamedPlus._ensure_range(kw.data[1]), kw.itr)
+    elseif length(kw.itr) >= 2
+        data = NamedPlus.outer(NamedPlus._ensure_range.(Tuple(kw.data))...)
+        NamedDimsArray(data, kw.itr)
+    else
+        error("range() with no arguments still doesn't mean anything")
+    end
+end
+
+#################### PRIMES ####################
+
+"""
+    :x' == :x′
+
+`adjoint(::Symbol)` adds unicode prime `′` to the end.
+"""
+Base.adjoint(s::Symbol) = NamedPlus.prime(s)
+
+####################

--- a/src/pirate.jl
+++ b/src/pirate.jl
@@ -1,3 +1,6 @@
+
+# This file is NOT loaded by default. You must say "@pirate NamedDims" to load it.
+
 #################### ZERO, ONES ####################
 
 _zero_doc = """

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -94,12 +94,6 @@ const ndv = NamedDimsArray{(:a,)}([1,2,3])
 @btime (() -> prime(ndv, :a))()                               #  6.678 ns (1 allocation: 16 bytes)
 =#
 
-"""
-    :x' == :x′
-
-`adjoint(::Symbol)` adds unicode prime `′` to the end.
-"""
-Base.adjoint(s::Symbol) = prime(s)
 
 #=
 AB = NamedDimsArray(rand(1:10, 2,3), (:a,:b))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,6 +232,8 @@ end
 end
 @testset "base piracy" begin
 
+    @pirate Base
+
     # Base behaviour
     @test ones() isa Array{Float64, 0}
     @test zeros() isa Array{Float64, 0}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,10 +108,10 @@ end
     vt = v'
     @test_skip  (@named {j} = v .+ v') == 2v # fixed on master of TransmuteDims, also OK on 1.3
     @test_skip  (@named {j} = v .+ vt) == 2v
-    c = ones(i=3) .+ im
+    c = named(ones(3), :i) .+ im
     ct = c'
-    @test_skip (@named {i} = c .+ c') == 2 .* ones(i=3) # fixed on master of TransmuteDims
-    @test_broken (@named {i} = c .+ ct) == 2 .* ones(i=3) # can't unwrap adjoint
+    @test_skip (@named {i} = c .+ c') == 2 .* named(ones(3), :i) # fixed on master of TransmuteDims
+    @test_skip (@named {i} = c .+ ct) == 2 .* named(ones(3), :i) # can't unwrap adjoint
 
 end
 @testset "rename & prime" begin
@@ -122,7 +122,7 @@ end
 
     @test dimnames(rename(m, :j => :k)) == (:i, :k)
     @test dimnames(rename(m, :j => :k, :i => :j)) == (:j, :k)
-    @test dimnames(rename(m, :j => :k, :k => :l)) == (:i, :l)
+    @test_broken dimnames(rename(m, :j => :k, :k => :l)) == (:i, :l) # changed to NamedDims version
     @test dimnames(rename(m, (:a, :b))) == (:a, :b)
 
     using NamedPlus: _prime
@@ -193,6 +193,8 @@ end
 
 end
 @testset "named int" begin
+
+    # @pirate NamedDims # not yet optional
 
     ni, nj = size(m)
     @test ni isa NamedInt


### PR DESCRIPTION
This only commits the piracy needed for `Base.zeros(i=4, j=10)` etc. when you ask for it, with a macro. 